### PR TITLE
[Fix] Add x-correlation-id header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "tgtg-scanner"
 packages = [{include = "tgtg_scanner"}]
 readme = "README.md"
 repository = "https://github.com/ihor-chaban/tgtg-scanner"
-version = "1.0.0+ihor-chaban.1.22.2"
+version = "1.1.0+ihor-chaban.1.22.2"
 
 [tool.poetry.dependencies]
 apprise = "^1.4.0"

--- a/tgtg_scanner/tgtg/tgtg_client.py
+++ b/tgtg_scanner/tgtg/tgtg_client.py
@@ -5,6 +5,7 @@ import logging
 import random
 import re
 import time
+import uuid
 from datetime import datetime
 from http import HTTPStatus
 from typing import List, Union
@@ -59,6 +60,8 @@ class TgtgSession(requests.Session):
         )
     )
 
+    correlation_id = str(uuid.uuid4())
+
     def __init__(
         self,
         user_agent: Union[str, None] = None,
@@ -78,6 +81,7 @@ class TgtgSession(requests.Session):
             "accept": "application/json",
             "content-type": "application/json; charset=utf-8",
             "Accept-Encoding": "gzip",
+            "x-correlation-id": self.correlation_id,
         }
         if user_agent:
             self.headers["user-agent"] = user_agent


### PR DESCRIPTION
## Summary
> Adds the x-correlation-id header to fix https://github.com/Der-Henning/tgtg/issues/590. The value is a randomly generated UUIDv4 just like the app uses. Please note that a relogin may be needed, as flagged datadome cookies seem to consistently trigger captchas.

<!-- markdownlint-disable-next-line MD041 -->
### Pull Request Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Did you make your Pull Request on the dev branch?
* [x] Does your submission pass tests? `make test`
* [x] Have you lint your code locally prior to submission? `make lint`
* [x] Could you build and run the docker images successfully? `make images`
* [x] Could you create a running executable? `make executable`
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran manual tests with your changes locally?
* [x] Have you updated the documentation for your changes, as applicable?
