### PR TITLE
[Fix] Create order without delay

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ repository = "https://github.com/ihor-chaban/tgtg-scanner"
 [tool.poetry]
 packages = [{include = "tgtg_scanner"}]
 requires-poetry = '>=2.0.0,<3.0.0'
-version = "1.4.1+ihor-chaban.1.25.0"
+version = "1.4.2+ihor-chaban.1.25.0"
 
 [tool.poetry.group.build.dependencies]
 pyinstaller = "^6.3.0"

--- a/tgtg_scanner/tgtg/tgtg_client.py
+++ b/tgtg_scanner/tgtg/tgtg_client.py
@@ -104,7 +104,7 @@ class TgtgSession(requests.Session):
         self._base_url = base_url
 
     def send(self, request: requests.PreparedRequest, *args, **kwargs) -> requests.Response:
-        if self.last_api_request:
+        if self.last_api_request and CREATE_ORDER_ENDPOINT not in request.url:
             wait = max(0, DEFAULT_MIN_TIME_BETWEEN_REQUESTS - (datetime.now() - self.last_api_request).seconds)
             log.debug(f"Waiting {wait} seconds.")
             time.sleep(wait)

--- a/tgtg_scanner/tgtg/tgtg_client.py
+++ b/tgtg_scanner/tgtg/tgtg_client.py
@@ -104,7 +104,7 @@ class TgtgSession(requests.Session):
         self._base_url = base_url
 
     def send(self, request: requests.PreparedRequest, *args, **kwargs) -> requests.Response:
-        if self.last_api_request and CREATE_ORDER_ENDPOINT not in request.url:
+        if self.last_api_request and request.url is not None and CREATE_ORDER_ENDPOINT not in request.url:
             wait = max(0, DEFAULT_MIN_TIME_BETWEEN_REQUESTS - (datetime.now() - self.last_api_request).seconds)
             log.debug(f"Waiting {wait} seconds.")
             time.sleep(wait)


### PR DESCRIPTION
## Summary

In the [v1.25.0 upstream release](https://github.com/Der-Henning/tgtg/releases/tag/v1.25.0), the `DEFAULT_MIN_TIME_BETWEEN_REQUESTS` delay was added for all API requests.
But it also delays order creation when a surprise bag is discovered before reserving it.
This fix allows order creation to bypass that delay and reserve a bag instantly.

### Pull Request Checklist

* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Did you make your Pull Request on the dev branch?
* [x] Does your submission pass tests? `make test`
* [x] Have you lint your code locally prior to submission? `make lint`
* [x] Could you build and run the docker images successfully? `make images`
* [x] Could you create a running executable? `make executable`
* [x] Have you added an explanation of what your changes do and why you'd like to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran manual tests with your changes locally?
* [x] Have you updated the documentation for your changes, as applicable?
